### PR TITLE
fix: update rust version

### DIFF
--- a/movethebytes/data-transfer/rust/Dockerfile
+++ b/movethebytes/data-transfer/rust/Dockerfile
@@ -1,4 +1,4 @@
-FROM rust:1.62-bullseye as builder
+FROM rust:1.64-bullseye as builder
 WORKDIR /usr/src/testplan
 
 RUN apt-get update && apt-get install -y cmake protobuf-compiler


### PR DESCRIPTION
Hey all, awesome project you got there. 
While running the tcp and quic testplans, I got the error message:
```
package `iroh-car v0.1.3` cannot be built because it requires rustc 1.63 or newer, while the currently active rustc version is 1.62.1
```
when I updated the rust version in the Docker image to 1.63, I got:
```
error: package `clap v4.1.1` cannot be built because it requires rustc 1.64.0 or newer, while the currently active rustc version is 1.63.0
```
Updating to 1.64 makes the tests run successfully.
Feel free to ignore or close this PR if this isn't necessary :)